### PR TITLE
Plugin must be recompiled

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ To use the plugin simple change the level using `rcon changelevel ...` as normal
 
 ## Configuration
 
-You can controll the location where it tries to download the map from by setting `sm_map_download_base` (defaults to `'http://fakkelbrigade.eu/maps'`)
+You can controll the location where it tries to download the map from by setting `sm_map_download_base` (defaults to `'http://dl.serveme.tf/maps'`)
 
 The plugin looks for maps at `${sm_map_download_base}/${map_name}.bsp`

--- a/plugin/mapdownloader.sp
+++ b/plugin/mapdownloader.sp
@@ -28,7 +28,7 @@ new CURL_Default_opt[][2] = {
 new Handle:g_hCvarUrl = INVALID_HANDLE;
 
 public OnPluginStart() {
-	g_hCvarUrl = CreateConVar("sm_map_download_base", "http://dl.serveme.tf/maps/", "map download url", FCVAR_PROTECTED);
+	g_hCvarUrl = CreateConVar("sm_map_download_base", "http://dl.serveme.tf/maps", "map download url", FCVAR_PROTECTED);
 
 	RegServerCmd("changelevel", HandleChangeLevelAction);
 }


### PR DESCRIPTION
fixed README.md to correct download url. Fixed mapdownloader.sp to have proper url (removed double /). Plugin needs to be recompiled.