### PR TITLE
Update fastdl to serveme.tf maps CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ To use the plugin simple change the level using `rcon changelevel ...` as normal
 
 ## Configuration
 
-You can controll the location where it tries to download the map from by setting `sm_map_download_base` (defaults to `'https://dl.serveme.tf/maps'`)
+You can control the location where it tries to download the map from by setting `sm_map_download_base` (defaults to `'https://fastdl.serveme.tf/maps'`)
 
 The plugin looks for maps at `${sm_map_download_base}/${map_name}.bsp`

--- a/plugin/mapdownloader.sp
+++ b/plugin/mapdownloader.sp
@@ -28,7 +28,7 @@ new CURL_Default_opt[][2] = {
 new Handle:g_hCvarUrl = INVALID_HANDLE;
 
 public OnPluginStart() {
-	g_hCvarUrl = CreateConVar("sm_map_download_base", "https://dl.serveme.tf/maps", "map download url", FCVAR_PROTECTED);
+	g_hCvarUrl = CreateConVar("sm_map_download_base", "https://fastdl.serveme.tf/maps", "map download url", FCVAR_PROTECTED);
 
 	RegServerCmd("changelevel", HandleChangeLevelAction);
 }


### PR DESCRIPTION
Hi, 

Thank you for this plugin. I noticed it previously used the fakkelbrigade.eu/maps and dl.serveme.tf/maps URLs for the files. These were both regionally hosted bare metal http download servers for use as `sv_downloadurl` in the EU serveme.tf region.
I've decided to have a more globally speedy CDN-ish approach for all serveme.tf regions and players around the world, which can also be used by anyone. This PR points to that new URL.